### PR TITLE
Allow same dexes in different network

### DIFF
--- a/reactComponents/src/searchbar/SearchBar.mock.ts
+++ b/reactComponents/src/searchbar/SearchBar.mock.ts
@@ -13,7 +13,78 @@ const MOCK_NETWORKS = [
     name: 'BNB Chain',
     icon: null,
     exchanges: [
-      { name: 'biswap' as ExchangeName }, { name: 'pancakeswap' as ExchangeName }, { name: 'mdex' as ExchangeName }
+      {
+        name: 'biswap' as ExchangeName
+      },
+      {
+        name: 'pancakeswap' as ExchangeName
+      },
+      {
+        name: 'mdex' as ExchangeName
+      }
+    ]
+  },
+  {
+    id: 'moonriver' as NetworkId,
+    name: 'Moonriver',
+    icon: null,
+    exchanges: [
+      {
+        id: 'solarbeam-moonriver',
+        name: 'solarbeam' as ExchangeName
+      }
+    ]
+  },
+  {
+    id: 'metis' as NetworkId,
+    name: 'Metis',
+    icon: null,
+    exchanges: [
+      {
+        name: 'netswap' as ExchangeName
+      },
+      {
+        name: 'hermesprotocol' as ExchangeName
+      }
+    ]
+  },
+  {
+    id: 'ethereum' as NetworkId,
+    name: 'Ethereum',
+    icon: null,
+    exchanges: [
+      {
+        name: 'sushiswap' as ExchangeName
+      },
+      {
+        name: 'uniswapv2' as ExchangeName
+      },
+      {
+        name: 'uniswapv3' as ExchangeName
+      }
+    ]
+  },
+  {
+    id: 'moonbeam' as NetworkId,
+    name: 'Moonbeam',
+    icon: null,
+    exchanges: [
+      {
+        name: 'beamswap' as ExchangeName
+      }
+    ]
+  },
+  {
+    id: 'polygon' as NetworkId,
+    name: 'Polygon',
+    icon: null,
+    exchanges: [
+      {
+        name: 'sushiswap' as ExchangeName
+      },      
+      {
+        name: 'uniswapv3' as ExchangeName
+      }
     ]
   }
 ];

--- a/reactComponents/src/searchbar/redux/tokenSearchSlice.ts
+++ b/reactComponents/src/searchbar/redux/tokenSearchSlice.ts
@@ -8,6 +8,23 @@ import config from '../config';
 
 const LOAD_LIMIT = Number(config.LOAD_LIMIT || 10);
 
+// 
+const isDuplicatedExchange = (exchange, networks, networkMap) => {
+  let isDuplicated = false;
+
+  networks.forEach((network) => {
+    if (networkMap[network.id]) {
+      const duplicated = network.exchanges.find(ex => ex === exchange);
+      if (duplicated) {
+        isDuplicated = true;
+        return;
+      }
+    }
+  });
+
+  return isDuplicated;
+}
+
 // Function that handles the "All" values of both the network and the exchange.
 // Consider that "no value" equates "All".
 const allValueHandler = (networkMap, exchangeMap, networks) => {
@@ -33,7 +50,7 @@ const allValueHandler = (networkMap, exchangeMap, networks) => {
         });
       }
     });
-    returnedExchangeMap = exchanges;
+    returnedExchangeMap = uniq(exchanges);
   }  
 
   // Returns the processed values of "networkMap" and "exchangeMap".
@@ -182,8 +199,9 @@ export const tokenSearchSlice = createSlice({
       if (!action.payload.checked) {
         action.payload.networks.forEach((network) => {
           if (network.id === action.payload.networkName) {
-            network.exchanges.forEach((exhange) => {
-              if (state.exchangeMap[exhange]) state.exchangeMap[exhange] = false;
+            network.exchanges.forEach((exchange) => {
+              const isDuplicated = isDuplicatedExchange(exchange, action.payload.networks, state.networkMap);
+              if (state.exchangeMap[exchange] && !isDuplicated) state.exchangeMap[exchange] = false;
             });
           } else return false;
         });

--- a/reactComponents/src/searchbar/redux/tokenSearchSlice.ts
+++ b/reactComponents/src/searchbar/redux/tokenSearchSlice.ts
@@ -8,17 +8,12 @@ import config from '../config';
 
 const LOAD_LIMIT = Number(config.LOAD_LIMIT || 10);
 
-// 
-const isDuplicatedExchange = (exchange, networks, networkMap) => {
-  let isDuplicated = false;
-
-  networks.forEach((network) => {
+// Check if duplicated exchange exists in selected network
+const isExchangeDuplicated = (exchange, networks, networkMap) => {
+  const isDuplicated = networks.some((network) => {
     if (networkMap[network.id]) {
       const duplicated = network.exchanges.find(ex => ex === exchange);
-      if (duplicated) {
-        isDuplicated = true;
-        return;
-      }
+      if (duplicated) return true;
     }
   });
 
@@ -200,7 +195,7 @@ export const tokenSearchSlice = createSlice({
         action.payload.networks.forEach((network) => {
           if (network.id === action.payload.networkName) {
             network.exchanges.forEach((exchange) => {
-              const isDuplicated = isDuplicatedExchange(exchange, action.payload.networks, state.networkMap);
+              const isDuplicated = isExchangeDuplicated(exchange, action.payload.networks, state.networkMap);
               if (state.exchangeMap[exchange] && !isDuplicated) state.exchangeMap[exchange] = false;
             });
           } else return false;

--- a/reactComponents/src/searchbar/tokenSearch/SearchFiltersNetworkSelectors.tsx
+++ b/reactComponents/src/searchbar/tokenSearch/SearchFiltersNetworkSelectors.tsx
@@ -6,6 +6,7 @@ import { Chip } from "./Chip"
 import Button from "./Button"
 import { RootState } from "../redux/store";
 import TokenSearchContext from '../Context/TokenSearch';
+import { NetworkType } from '../../types';
 
 export const FilterNetworkAll = (): JSX.Element => {
   const dispatch = useDispatch();
@@ -30,8 +31,8 @@ export const FilterNetworkAll = (): JSX.Element => {
 
 export const FilterNetworkSelectors = (): JSX.Element => {
   const renderProps = useContext(TokenSearchContext);
-  const networks: any = [...renderProps.networks];
-  const networkItems: any = useMemo(
+  const networks: NetworkType[] = [...renderProps.networks];
+  const networkItems = useMemo(
     () =>
       networks.map((network) => {
         return { id: network.id, exchanges: network.exchanges.map((exhange) => exhange.name) };
@@ -65,5 +66,9 @@ export const FilterNetworkSelectors = (): JSX.Element => {
   };
 
   // RENDERING.
-  return networks.map((network) => networkElement(network));
+  return (
+    <>
+      {networks.map((network) => networkElement(network))}
+    </>
+  )
 };


### PR DESCRIPTION
1. Implementation
- Add new type to identify same dex in different network
- Update redux action/state
- Update storybook mockup data

2. Test Flow
- In storybook, you will see `Ethereum` and `Polygon` network
- Select `Ethereum` and will see 3 dexes(Sushiswap, Uniswap V2 and Uniswap V3) and then select Sushiswap and Uniswap V3
- Select `Polygon` and Uniswap V2 and Sushiswap will be remained as selected status .
- Deselect `Ethereum` and Uniswap V2 will be get rid of but Sushiswap will be remained because `Polygon` network still selected.
