### PR TITLE
Rt 694 token ellipsed

### DIFF
--- a/reactComponents/src/searchbar/tokenSearch/ResultDetail.tsx
+++ b/reactComponents/src/searchbar/tokenSearch/ResultDetail.tsx
@@ -39,7 +39,7 @@ const StyledDetailList = styled(StyledGridRow)`
 
     .pair-tokens {
       display: grid;
-      grid-template-columns: 40px 40px;
+      grid-template-columns: minmax(40px, 80px) minmax(40px, 80px);
       grid-gap: 10px;
       align-items: center;
       justify-content: center;


### PR DESCRIPTION
Jira Ticket
https://romeblockchain.atlassian.net/browse/RT-694

Description;
The tokens in the search bar are still being “ellipsed” - there is enough room for them to be fully shown