### PR TITLE
Feat add selected wallet

### DIFF
--- a/WalletContext/package.json
+++ b/WalletContext/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@romeblockchain/wallet",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Implmentation of web3react-v8 for RT widgets",
   "main": "./dist/index.js",
   "type": "module",

--- a/WalletContext/package.json
+++ b/WalletContext/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@romeblockchain/wallet",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Implmentation of web3react-v8 for RT widgets",
   "main": "./dist/index.js",
   "type": "module",

--- a/WalletContext/src/context/WalletProvider.tsx
+++ b/WalletContext/src/context/WalletProvider.tsx
@@ -11,9 +11,9 @@ import useLocalStorage from '../hooks/useLocalStorage'
 import { WalletInfo } from '../types'
 
 export const initialConnectors: [MetaMask | WalletConnect | Network, Web3ReactHooks][] = [
+  [network, networkHooks],
   [metaMask, metaMaskHooks],
   [walletConnect, walletConnectHooks],
-  [network, networkHooks],
 ]
 
 export const SUPPORTED_WALLETS: { [key: string]: WalletInfo } = {

--- a/WalletContext/src/context/WalletProvider.tsx
+++ b/WalletContext/src/context/WalletProvider.tsx
@@ -31,12 +31,14 @@ export const SUPPORTED_WALLETS: { [key: string]: WalletInfo } = {
     mobile: true,
   },
 }
-interface IWalletContext {
+export interface IWalletContext {
   setSelectedWallet: (Wallet: Wallet) => void
+  selectedWallet: Wallet | undefined
 }
 
 export const WalletContext = React.createContext<IWalletContext>({
   setSelectedWallet: () => {},
+  selectedWallet: undefined,
 })
 
 export default function ProviderExample({ children }: any) {
@@ -67,7 +69,7 @@ export default function ProviderExample({ children }: any) {
   }, [])
 
   return (
-    <WalletContext.Provider value={{ setSelectedWallet }}>
+    <WalletContext.Provider value={{ selectedWallet, setSelectedWallet }}>
       <Web3ReactProvider connectors={connectors}>{children}</Web3ReactProvider>
     </WalletContext.Provider>
   )

--- a/WalletContext/src/hooks/useWallets.ts
+++ b/WalletContext/src/hooks/useWallets.ts
@@ -6,6 +6,5 @@ export function useWallets() {
   if (context === undefined) {
     throw new Error('useWallet must be used within a useWalletsProvider')
   }
-  const { setSelectedWallet } = context
-  return { setSelectedWallet }
+  return context
 }

--- a/WalletContext/src/index.ts
+++ b/WalletContext/src/index.ts
@@ -2,5 +2,6 @@ import WalletProvider, { SUPPORTED_WALLETS } from './context/WalletProvider'
 import { useWeb3React } from '@web3-react/core'
 import { useWallets } from './hooks/useWallets'
 import { Wallet } from './types'
+import { getAddChainParameters } from './chains'
 
-export { WalletProvider, SUPPORTED_WALLETS, useWeb3React, Wallet, useWallets }
+export { WalletProvider, SUPPORTED_WALLETS, useWeb3React, Wallet, useWallets, getAddChainParameters }


### PR DESCRIPTION
1. reorganize initial connectors so that network connector will be used first. this makes sure that on inital load, DAPPS can use the network to load blockchain data.
2. expose selectedWallet variable so that developers can expose which wallet is currently selected (active)
3. expose getaddchainparameters function so that developers can easily fetch the chainparameters when adding a new network to a user's metamask wallet