### PR TITLE
fix: import latest version of bridge into wallet

### DIFF
--- a/WalletContext/README.md
+++ b/WalletContext/README.md
@@ -2,6 +2,7 @@
 
 Current version is 0.1.29
 | version | description |
+| 0.1.30 | use latest version of bridge to allow type consistency
 | 0.1.29 | remove window.localstorage.clear
 | 0.1.27 | always return chain information
 | 0.1.25 | delete deprecated testnets

--- a/WalletContext/package.json
+++ b/WalletContext/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@romeblockchain/wallet",
-  "version": "0.1.29",
+  "version": "0.1.30",
   "description": "Implmentation of web3react-v8 for RT widgets",
   "main": "./dist/index.js",
   "type": "module",
@@ -32,7 +32,7 @@
   "license": "ISC",
   "dependencies": {
     "@coinbase/wallet-sdk": "^3.5.4",
-    "@romeblockchain/bridge": "^0.0.3",
+    "@romeblockchain/bridge": "^0.0.5",
     "@types/ua-parser-js": "^0.7.36",
     "@walletconnect/ethereum-provider": "^1.7.8",
     "@walletconnect/jsonrpc-http-connection": "^1.0.2",


### PR DESCRIPTION
This is needed because:
The handleConnect function in the wallet package has the following type:
```
    handleConnect: (wallet: WalletInfo, chainParams: number | AddEthereumChainParameter, widgetBridge?: WidgetBridge) => Promise<void>;

```
When you go to use a newer version of the bridge (with different types - ie no `namespaceCookies`, or added `sendAnalyticsEvent`) in a widget then we get a type error.

This is a hotfix to use the latest bridge in the wallet package, so we can:
1) import the latest wallet
2) import the latest bridge

A hacky workaround would be to type the widgetBridge object being passed to the handleConnect function as `any`

---
Maybe we want to find a workaround so we don't need to pass the WidgetBridge into the wallet directly